### PR TITLE
fix: Write weights file to Docker base dir

### DIFF
--- a/app/models/cnn_lstm_ae.py
+++ b/app/models/cnn_lstm_ae.py
@@ -36,7 +36,7 @@ class CnnLstmAe(tf.keras.Model):
 
   @classmethod
   def get_weight_file(self):
-    p = os.environ.get('ROOT_PATH') or ''
+    p = os.environ.get('ROOT_PATH') or '/'
     return p + 'cnn_lstm_ae-weights.h5'
 
   def set_model_file(self, model_file):


### PR DESCRIPTION
Write weights file to Docker base directory to easily access in container.